### PR TITLE
Feature/edit post

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,7 @@ If you send the header incorrectly it will respond with 422 status code. If your
   ],
 }
 ```
+
+#### Edit a post
+
+You can edit a post by making a PUT request to `/posts/:id` where this id is the post id. It returns the same status codes as in send post, and needs the same object to make de uptade.

--- a/src/controllers/postsController.js
+++ b/src/controllers/postsController.js
@@ -116,6 +116,8 @@ export const deletePost = async (req, res) => {
 
     await tagsRepository.deletePostMentions(id);
     await postsRepository.deletePostById(id);
+    await tagsRepository.clearUnmentionedTags();
+    await urlsRepository.clearUnmentionedUrls();
     return res.sendStatus(200);
   } catch (error) {
     console.error(error);

--- a/src/controllers/postsController.js
+++ b/src/controllers/postsController.js
@@ -113,6 +113,7 @@ export const deletePost = async (req, res) => {
       return res.sendStatus(401);
     }
 
+    await postsRepository.deletePostMentions(id);
     await postsRepository.deletePostById(id);
     return res.sendStatus(200);
   } catch (error) {

--- a/src/controllers/postsController.js
+++ b/src/controllers/postsController.js
@@ -4,6 +4,7 @@ import {
   postsRepository,
   usersRepository,
   tagsRepository,
+  urlsRepository,
 } from '../repositories/index.js';
 
 // Locally used functions
@@ -12,9 +13,9 @@ const getUrlMetadata = async (link) => {
   const { url, title, image, description } = await urlMetadata(link, {
     descriptionLength: 50,
   });
-  let urlInfo = await postsRepository.getUrlByUrl(url);
+  let urlInfo = await urlsRepository.getUrlByUrl(url);
   if (!urlInfo) {
-    urlInfo = await postsRepository.createUrl(url, title, image, description);
+    urlInfo = await urlsRepository.createUrl(url, title, image, description);
   }
 
   return urlInfo;

--- a/src/controllers/postsController.js
+++ b/src/controllers/postsController.js
@@ -113,7 +113,7 @@ export const deletePost = async (req, res) => {
       return res.sendStatus(401);
     }
 
-    await postsRepository.deletePostMentions(id);
+    await tagsRepository.deletePostMentions(id);
     await postsRepository.deletePostById(id);
     return res.sendStatus(200);
   } catch (error) {

--- a/src/repositories/index.js
+++ b/src/repositories/index.js
@@ -1,3 +1,4 @@
 export * as usersRepository from './usersRepository.js';
 export * as postsRepository from './postsRepository.js';
 export * as tagsRepository from './tagsRepository.js';
+export * as urlsRepository from './urlsRepository.js';

--- a/src/repositories/postsRepository.js
+++ b/src/repositories/postsRepository.js
@@ -105,12 +105,6 @@ export const deletePostById = async (id) => {
   return posts[0];
 };
 
-export const deletePostMentions = async (postId) => {
-  await connection.query('DELETE FROM tags_mentions WHERE post_id = $1', [
-    postId,
-  ]);
-};
-
 export const editPostById = async (postId, content, urlId) => {
   const { rows: post } = await connection.query(
     `

--- a/src/repositories/postsRepository.js
+++ b/src/repositories/postsRepository.js
@@ -60,29 +60,6 @@ export const createPost = async (userId, content, urlId) => {
   return post[0];
 };
 
-export const createUrl = async (url, title, image, description) => {
-  const { rows: urlMetadata } = await connection.query(
-    `
-      INSERT INTO urls(url, title, image, description)
-      VALUES ($1, $2, $3, $4)
-      RETURNING *
-    `,
-    [url, title, image, description]
-  );
-  return urlMetadata[0];
-};
-
-export const getUrlByUrl = async (url) => {
-  const { rows: urlMetadata } = await connection.query(
-    `
-      SELECT * FROM urls
-      WHERE url = $1
-    `,
-    [url]
-  );
-  return urlMetadata[0];
-};
-
 export const getPostById = async (id) => {
   const { rows: posts } = await connection.query(
     `

--- a/src/repositories/postsRepository.js
+++ b/src/repositories/postsRepository.js
@@ -104,3 +104,16 @@ export const deletePostById = async (id) => {
   );
   return posts[0];
 };
+
+export const editPostById = async (postId, content, urlId) => {
+  const { rows: post } = await connection.query(
+    `
+      UPDATE posts
+      SET content = $2, url_id = $3
+      WHERE id = $1
+      RETURNING *
+    `,
+    [postId, content, urlId]
+  );
+  return post[0];
+};

--- a/src/repositories/postsRepository.js
+++ b/src/repositories/postsRepository.js
@@ -105,6 +105,12 @@ export const deletePostById = async (id) => {
   return posts[0];
 };
 
+export const deletePostMentions = async (postId) => {
+  await connection.query('DELETE FROM tags_mentions WHERE post_id = $1', [
+    postId,
+  ]);
+};
+
 export const editPostById = async (postId, content, urlId) => {
   const { rows: post } = await connection.query(
     `

--- a/src/repositories/tagsRepository.js
+++ b/src/repositories/tagsRepository.js
@@ -28,3 +28,9 @@ export const deletePostMentions = async (postId) => {
     postId,
   ]);
 };
+
+export const clearUnmentionedTags = async () => {
+  await connection.query(
+    'DELETE FROM tags WHERE id NOT IN (SELECT tag_id FROM tag_mentions)'
+  );
+};

--- a/src/repositories/tagsRepository.js
+++ b/src/repositories/tagsRepository.js
@@ -22,3 +22,9 @@ export const getTagByName = async (tagName) => {
   );
   return tag[0];
 };
+
+export const deletePostMentions = async (postId) => {
+  await connection.query('DELETE FROM tags_mentions WHERE post_id = $1', [
+    postId,
+  ]);
+};

--- a/src/repositories/urlsRepository.js
+++ b/src/repositories/urlsRepository.js
@@ -1,0 +1,30 @@
+import connection from '../databases/postgres.js';
+
+export const createUrl = async (url, title, image, description) => {
+  const { rows: urlMetadata } = await connection.query(
+    `
+      INSERT INTO urls(url, title, image, description)
+      VALUES ($1, $2, $3, $4)
+      RETURNING *
+    `,
+    [url, title, image, description]
+  );
+  return urlMetadata[0];
+};
+
+export const getUrlByUrl = async (url) => {
+  const { rows: urlMetadata } = await connection.query(
+    `
+      SELECT * FROM urls
+      WHERE url = $1
+    `,
+    [url]
+  );
+  return urlMetadata[0];
+};
+
+export const clearUnmentionedUrls = async () => {
+  await connection.query(
+    'DELETE FROM urls WHERE id NOT IN (SELECT url_id FROM posts)'
+  );
+};

--- a/src/routers/postsRouter.js
+++ b/src/routers/postsRouter.js
@@ -31,5 +31,12 @@ postsRouter.delete(
   postsMiddlewares.checkReqParams,
   postsController.deletePost
 );
+postsRouter.put(
+  '/posts/:id',
+  authMiddlewares.tokenValidation,
+  postsMiddlewares.checkSendPostBody,
+  postsMiddlewares.checkReqParams,
+  postsController.editPost
+);
 
 export default postsRouter;


### PR DESCRIPTION
# Summary

This PR creates a new feature to edit a timeline post. It uses the same middlewares as in send post and delete post. To edit the post you will need to send the same object that we use to create a post. When editing a post recalculates used urls and delete unused ones and do the same with hashtags.

# Other changes

Also made a change on the delete route because in order to delete a post, it needs to delete the tag mentions of that post, since the post is referenced and cannot be deleted without it. Its important to note this because when making likes feature it will need to change again.

Created a new repository for urls since its functions were polluting the posts repository.